### PR TITLE
Update control-loong64 to avoid packagename warning

### DIFF
--- a/UotanToolbox/Assets/Linux/control-loong64
+++ b/UotanToolbox/Assets/Linux/control-loong64
@@ -1,5 +1,5 @@
 Maintainer: mujianwu <lrh15563910083@163.com>
-Package: UotanToolbox
+Package: uotantoolbox
 Version: 3.2.1
 Section: devel
 Priority: optional


### PR DESCRIPTION
Package name should not contain any capital letter