### PR TITLE
Update Linux configuration and desktop entry

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,6 +87,173 @@ jobs:
         dpkg-deb --root-owner-group --build ./staging_folder/ ./UotanToolbox_Linux_arm64_${{ inputs.VERSION }}.deb
         rm -rf ./staging_folder/*
 
+    - name: Install packaging tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y rpm libarchive-tools zstd fakeroot libfuse2
+        sudo gem install fpm
+        wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
+        chmod +x ./appimagetool
+        ./appimagetool --appimage-extract > /dev/null 2>&1
+        mv squashfs-root appimagetool-extracted
+        wget -q https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-aarch64
+
+    - name: Make arch-x64
+      run: |
+        mkdir -p archpkg/usr/bin archpkg/usr/lib/UotanToolbox archpkg/usr/share/applications archpkg/usr/share/pixmaps
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox archpkg/usr/bin/UotanToolbox
+        chmod +x archpkg/usr/bin/UotanToolbox
+        cp -r ./publish-x64/* archpkg/usr/lib/UotanToolbox/
+        chmod -R a+rX archpkg/usr/lib/UotanToolbox/
+        chmod +x archpkg/usr/lib/UotanToolbox/UotanToolbox
+        cp -r ./UotanToolboxNT.Binary/Linux_AMD64/* archpkg/usr/lib/UotanToolbox/
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop archpkg/usr/share/applications/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png archpkg/usr/share/pixmaps/UotanToolbox.png
+        cd archpkg
+        cat > .PKGINFO << PKGEOF
+        pkgname = uotantoolbox
+        pkgver = ${{ inputs.VERSION }}-1
+        pkgdesc = Advanced, Modern Toolbox for Geeks.
+        url = https://github.com/Uotan-Dev/UotanToolboxNT
+        builddate = $(date +%s)
+        packager = mujianwu <lrh15563910083@163.com>
+        size = $(du -sb usr | cut -f1)
+        arch = x86_64
+        license = custom
+        depend = usbutils
+        depend = android-tools
+        PKGEOF
+        sed -i 's/^        //' .PKGINFO
+        env LANG=C bsdtar -czf .MTREE --format=mtree \
+          --options='!all,use-set,type,uid,gid,mode,time,size,sha256,link' \
+          .PKGINFO usr
+        env LANG=C fakeroot -- bsdtar -cf - .MTREE .PKGINFO usr | zstd -c -T0 > \
+          ../UotanToolbox_Linux_x64_${{ inputs.VERSION }}.pkg.tar.zst
+        cd ..
+        rm -rf archpkg
+
+    - name: Make arch-arm64
+      run: |
+        mkdir -p archpkg/usr/bin archpkg/usr/lib/UotanToolbox archpkg/usr/share/applications archpkg/usr/share/pixmaps
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox archpkg/usr/bin/UotanToolbox
+        chmod +x archpkg/usr/bin/UotanToolbox
+        cp -r ./publish-arm64/* archpkg/usr/lib/UotanToolbox/
+        chmod -R a+rX archpkg/usr/lib/UotanToolbox/
+        chmod +x archpkg/usr/lib/UotanToolbox/UotanToolbox
+        cp -r ./UotanToolboxNT.Binary/Linux_AArch64/* archpkg/usr/lib/UotanToolbox/
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop archpkg/usr/share/applications/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png archpkg/usr/share/pixmaps/UotanToolbox.png
+        cd archpkg
+        cat > .PKGINFO << PKGEOF
+        pkgname = uotantoolbox
+        pkgver = ${{ inputs.VERSION }}-1
+        pkgdesc = Advanced, Modern Toolbox for Geeks.
+        url = https://github.com/Uotan-Dev/UotanToolboxNT
+        builddate = $(date +%s)
+        packager = mujianwu <lrh15563910083@163.com>
+        size = $(du -sb usr | cut -f1)
+        arch = aarch64
+        license = custom
+        depend = usbutils
+        depend = android-tools
+        PKGEOF
+        sed -i 's/^        //' .PKGINFO
+        env LANG=C bsdtar -czf .MTREE --format=mtree \
+          --options='!all,use-set,type,uid,gid,mode,time,size,sha256,link' \
+          .PKGINFO usr
+        env LANG=C fakeroot -- bsdtar -cf - .MTREE .PKGINFO usr | zstd -c -T0 > \
+          ../UotanToolbox_Linux_arm64_${{ inputs.VERSION }}.pkg.tar.zst
+        cd ..
+        rm -rf archpkg
+
+    - name: Make rpm-x64
+      run: |
+        mkdir -p rpmpkg/usr/bin rpmpkg/usr/lib/UotanToolbox rpmpkg/usr/share/applications rpmpkg/usr/share/pixmaps
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox rpmpkg/usr/bin/UotanToolbox
+        chmod +x rpmpkg/usr/bin/UotanToolbox
+        cp -r ./publish-x64/* rpmpkg/usr/lib/UotanToolbox/
+        chmod -R a+rX rpmpkg/usr/lib/UotanToolbox/
+        chmod +x rpmpkg/usr/lib/UotanToolbox/UotanToolbox
+        cp -r ./UotanToolboxNT.Binary/Linux_AMD64/* rpmpkg/usr/lib/UotanToolbox/
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop rpmpkg/usr/share/applications/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png rpmpkg/usr/share/pixmaps/UotanToolbox.png
+        fpm -s dir -t rpm -n uotantoolbox -v ${{ inputs.VERSION }} \
+          -a x86_64 \
+          --maintainer "mujianwu <lrh15563910083@163.com>" \
+          --description "Advanced, Modern Toolbox for Geeks." \
+          --url "https://github.com/Uotan-Dev/UotanToolboxNT" \
+          --license "custom" \
+          -d "usbutils" \
+          -d "android-tools" \
+          -C ./rpmpkg \
+          -p ./UotanToolbox_Linux_x64_${{ inputs.VERSION }}.rpm
+        rm -rf rpmpkg
+
+    - name: Make rpm-arm64
+      run: |
+        mkdir -p rpmpkg/usr/bin rpmpkg/usr/lib/UotanToolbox rpmpkg/usr/share/applications rpmpkg/usr/share/pixmaps
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox rpmpkg/usr/bin/UotanToolbox
+        chmod +x rpmpkg/usr/bin/UotanToolbox
+        cp -r ./publish-arm64/* rpmpkg/usr/lib/UotanToolbox/
+        chmod -R a+rX rpmpkg/usr/lib/UotanToolbox/
+        chmod +x rpmpkg/usr/lib/UotanToolbox/UotanToolbox
+        cp -r ./UotanToolboxNT.Binary/Linux_AArch64/* rpmpkg/usr/lib/UotanToolbox/
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop rpmpkg/usr/share/applications/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png rpmpkg/usr/share/pixmaps/UotanToolbox.png
+        fpm -s dir -t rpm -n uotantoolbox -v ${{ inputs.VERSION }} \
+          -a aarch64 \
+          --maintainer "mujianwu <lrh15563910083@163.com>" \
+          --description "Advanced, Modern Toolbox for Geeks." \
+          --url "https://github.com/Uotan-Dev/UotanToolboxNT" \
+          --license "custom" \
+          -d "usbutils" \
+          -d "android-tools" \
+          -C ./rpmpkg \
+          -p ./UotanToolbox_Linux_arm64_${{ inputs.VERSION }}.rpm
+        rm -rf rpmpkg
+
+    - name: Make AppImage-x64
+      run: |
+        mkdir -p AppDir/usr/bin AppDir/usr/lib/UotanToolbox AppDir/usr/share/applications AppDir/usr/share/pixmaps
+        cp -r ./publish-x64/* AppDir/usr/lib/UotanToolbox/
+        chmod -R a+rX AppDir/usr/lib/UotanToolbox/
+        chmod +x AppDir/usr/lib/UotanToolbox/UotanToolbox
+        cp -r ./UotanToolboxNT.Binary/Linux_AMD64/* AppDir/usr/lib/UotanToolbox/
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop AppDir/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png AppDir/UotanToolbox.png
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop AppDir/usr/share/applications/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png AppDir/usr/share/pixmaps/UotanToolbox.png
+        cat > AppDir/AppRun << 'APPEOF'
+        #!/bin/bash
+        HERE="$(dirname "$(readlink -f "${0}")")"
+        exec "$HERE/usr/lib/UotanToolbox/UotanToolbox" "$@"
+        APPEOF
+        sed -i 's/^        //' AppDir/AppRun
+        chmod +x AppDir/AppRun
+        ARCH=x86_64 ./appimagetool-extracted/AppRun AppDir ./UotanToolbox_Linux_x64_${{ inputs.VERSION }}.AppImage
+        rm -rf AppDir
+
+    - name: Make AppImage-arm64
+      run: |
+        mkdir -p AppDir/usr/bin AppDir/usr/lib/UotanToolbox AppDir/usr/share/applications AppDir/usr/share/pixmaps
+        cp -r ./publish-arm64/* AppDir/usr/lib/UotanToolbox/
+        chmod -R a+rX AppDir/usr/lib/UotanToolbox/
+        chmod +x AppDir/usr/lib/UotanToolbox/UotanToolbox
+        cp -r ./UotanToolboxNT.Binary/Linux_AArch64/* AppDir/usr/lib/UotanToolbox/
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop AppDir/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png AppDir/UotanToolbox.png
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.desktop AppDir/usr/share/applications/UotanToolbox.desktop
+        cp /home/runner/work/UotanToolboxNT/UotanToolboxNT/UotanToolbox/Assets/Linux/UotanToolbox.png AppDir/usr/share/pixmaps/UotanToolbox.png
+        cat > AppDir/AppRun << 'APPEOF'
+        #!/bin/bash
+        HERE="$(dirname "$(readlink -f "${0}")")"
+        exec "$HERE/usr/lib/UotanToolbox/UotanToolbox" "$@"
+        APPEOF
+        sed -i 's/^        //' AppDir/AppRun
+        chmod +x AppDir/AppRun
+        ARCH=aarch64 ./appimagetool-extracted/AppRun --runtime-file runtime-aarch64 AppDir ./UotanToolbox_Linux_arm64_${{ inputs.VERSION }}.AppImage
+        rm -rf AppDir
+
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/UotanToolbox/Assets/Linux/UotanToolbox.desktop
+++ b/UotanToolbox/Assets/Linux/UotanToolbox.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=3.6.1
+Version=1.5
 Name=UotanToolbox
 GenericName=UotanToolbox
 Icon=UotanToolbox


### PR DESCRIPTION
This pull request adds significant improvements to the Linux packaging and distribution workflow for `UotanToolbox`, supporting multiple package formats and architectures. The main changes include adding build steps for Arch Linux (`.pkg.tar.zst`), RPM, and AppImage packages for both x64 and arm64 architectures, as well as updating the application version in the desktop entry file.

**Packaging and Distribution Enhancements:**

* Added installation of required packaging tools and dependencies in the GitHub Actions workflow, including `rpm`, `libarchive-tools`, `zstd`, `fakeroot`, `libfuse2`, `fpm`, and AppImage tools.
* Implemented build steps to create Arch Linux packages (`.pkg.tar.zst`) for both x64 and arm64 architectures, including custom `.PKGINFO` generation and dependency specification.
* Added steps to build RPM packages for x64 and arm64 using `fpm`, with proper metadata and dependencies.
* Introduced AppImage packaging for both x64 and arm64, including extraction and handling of the AppImage runtime for arm64.

**Version Update:**

* Updated the `Version` field in the `UotanToolbox.desktop` file from `3.6.1` to `1.5` to reflect the current application version.